### PR TITLE
xp fix on ex4.10

### DIFF
--- a/chapter4.md
+++ b/chapter4.md
@@ -2002,7 +2002,7 @@ Ex().test_correct(check_result(), [
 
 ```yaml
 type: NormalExercise 
-xp: 0 
+xp: 100 
 key: 7b3afeed2f   
 ```
 


### PR DESCRIPTION
Had an exercise with xp = 0. Is now set to 100, bc it was a `NormalExercise`.